### PR TITLE
added support for union types

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,20 @@
 
 `graphql-2-json-schema` package
 
----
+-----------
 
 Transform a GraphQL Schema introspection file to a valid JSON Schema.
 
 ## Usage
 
 ```ts
-import { graphqlSync, getIntrospectionQuery, IntrospectionQuery } from 'graphql'
+import {
+    graphqlSync,
+    getIntrospectionQuery,
+    IntrospectionQuery
+} from 'graphql';
 
-import { fromIntrospectionQuery } from 'graphql-2-json-schema'
+import { fromIntrospectionQuery } from 'graphql-2-json-schema';
 
 const options = {
   // Whether or not to ignore GraphQL internals that are probably not relevant
@@ -24,14 +28,13 @@ const options = {
   // Defaults to `false` for backwards compatibility, but in future versions
   // the effect of `true` is likely going to be the default and only way. It is
   // highly recommended that new implementations set this value to `true`.
-  nullableArrayItems: true,
+  nullableArrayItems: true
 }
 
 // schema is your GraphQL schema.
-const introspection = graphqlSync(schema, getIntrospectionQuery())
-  .data as IntrospectionQuery
+const introspection = graphqlSync(schema, getIntrospectionQuery()).data as IntrospectionQuery;
 
-const jsonSchema = fromIntrospectionQuery(introspection, options)
+const jsonSchema = fromIntrospectionQuery(introspection, options);
 ```
 
 ## Example
@@ -39,61 +42,71 @@ const jsonSchema = fromIntrospectionQuery(introspection, options)
 ### Input
 
 ```graphql
-type Todo {
-  id: String!
-  name: String!
-  completed: Boolean
-  color: Color
+  type Todo {
+      id: String!
+      name: String!
+      completed: Boolean
+      color: Color
 
-  "A field that requires an argument"
-  colors(filter: [Color!]!): [Color!]!
-}
+      "A field that requires an argument"
+      colors(
+        filter: [Color!]!
+      ): [Color!]!
+  }
 
-type SimpleTodo {
-  id: String!
-  name: String!
-}
-
-union TodoUnion = Todo | SimpleTodo
-
-input TodoInputType {
-  name: String!
-  completed: Boolean
-  color: Color = RED
-}
-
-enum Color {
-  "Red color"
-  RED
-  "Green color"
-  GREEN
-}
-
-type Query {
-  "A Query with 1 required argument and 1 optional argument"
-  todo(
+  type SimpleTodo {
     id: String!
-    "A default value of false"
-    isCompleted: Boolean = false
-  ): Todo
+    name: String!
+  }
 
-  "Returns a list (or null) that can contain null values"
-  todos(
-    "Reauired argument that is a list that cannot contain null values"
-    ids: [String!]!
-  ): [Todo]
-}
+  union TodoUnion = Todo | SimpleTodo
 
-type Mutation {
-  "A Mutation with 1 required argument"
-  create_todo(todo: TodoInputType!): Todo!
+  input TodoInputType {
+      name: String!
+      completed: Boolean
+      color: Color=RED
+  }
 
-  "A Mutation with 2 required arguments"
-  update_todo(id: String!, data: TodoInputType!): Todo!
+  enum Color {
+      "Red color"
+      RED
+      "Green color"
+      GREEN
+  }
 
-  "Returns a list (or null) that can contain null values"
-  update_todos(ids: [String!]!, data: TodoInputType!): [Todo]
-}
+  type Query {
+      "A Query with 1 required argument and 1 optional argument"
+      todo(
+        id: String!,
+        "A default value of false"
+        isCompleted: Boolean=false
+      ): Todo
+
+      "Returns a list (or null) that can contain null values"
+      todos(
+        "Required argument that is a list that cannot contain null values"
+        ids: [String!]!
+      ): [Todo]
+  }
+
+  type Mutation {
+      "A Mutation with 1 required argument"
+      create_todo(
+        todo: TodoInputType!
+      ): Todo!
+
+      "A Mutation with 2 required arguments"
+      update_todo(
+        id: String!,
+        data: TodoInputType!
+      ): Todo!
+
+      "Returns a list (or null) that can contain null values"
+      update_todos(
+        ids: [String!]!
+        data: TodoInputType!
+      ): [Todo]
+  }
 ```
 
 ### Output
@@ -142,7 +155,7 @@ const options = { nullableArrayItems: true }
               type: 'object',
               properties: {
                 ids: {
-                  description: 'Reauired argument that is a list that cannot contain null values',
+                  description: 'Required argument that is a list that cannot contain null values',
                   type: 'array',
                   items: { '$ref': '#/definitions/String' }
                 }

--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ const jsonSchema = fromIntrospectionQuery(introspection, options);
       ): [Color!]!
   }
 
+  type SimpleTodo {
+    id: String!
+    name: String!
+  }
+
+  union TodoUnion = Todo | SimpleTodo
+
   input TodoInputType {
       name: String!
       completed: Boolean
@@ -277,6 +284,34 @@ const options = { nullableArrayItems: true }
         }
       },
       required: [ 'id', 'name', 'colors' ]
+    },
+    SimpleTodo: {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'object',
+          properties: {
+            return: { '$ref': '#/definitions/String' },
+            arguments: { type: 'object', properties: {}, required: [] }
+          },
+          required: []
+        },
+        name: {
+          type: 'object',
+          properties: {
+            return: { '$ref': '#/definitions/String' },
+            arguments: { type: 'object', properties: {}, required: [] }
+          },
+          required: []
+        }
+      },
+      required: [ 'id', 'name' ]
+    },
+    TodoUnion: {
+      anyOf: [
+        { '$ref': '#/definitions/Todo' },
+        { '$ref': '#/definitions/SimpleTodo' }
+      ]
     },
     TodoInputType: {
       type: 'object',

--- a/README.md
+++ b/README.md
@@ -2,20 +2,16 @@
 
 `graphql-2-json-schema` package
 
------------
+---
 
 Transform a GraphQL Schema introspection file to a valid JSON Schema.
 
 ## Usage
 
 ```ts
-import {
-    graphqlSync,
-    getIntrospectionQuery,
-    IntrospectionQuery
-} from 'graphql';
+import { graphqlSync, getIntrospectionQuery, IntrospectionQuery } from 'graphql'
 
-import { fromIntrospectionQuery } from 'graphql-2-json-schema';
+import { fromIntrospectionQuery } from 'graphql-2-json-schema'
 
 const options = {
   // Whether or not to ignore GraphQL internals that are probably not relevant
@@ -28,13 +24,14 @@ const options = {
   // Defaults to `false` for backwards compatibility, but in future versions
   // the effect of `true` is likely going to be the default and only way. It is
   // highly recommended that new implementations set this value to `true`.
-  nullableArrayItems: true
+  nullableArrayItems: true,
 }
 
 // schema is your GraphQL schema.
-const introspection = graphqlSync(schema, getIntrospectionQuery()).data as IntrospectionQuery;
+const introspection = graphqlSync(schema, getIntrospectionQuery())
+  .data as IntrospectionQuery
 
-const jsonSchema = fromIntrospectionQuery(introspection, options);
+const jsonSchema = fromIntrospectionQuery(introspection, options)
 ```
 
 ## Example
@@ -42,71 +39,61 @@ const jsonSchema = fromIntrospectionQuery(introspection, options);
 ### Input
 
 ```graphql
-  type Todo {
-      id: String!
-      name: String!
-      completed: Boolean
-      color: Color
+type Todo {
+  id: String!
+  name: String!
+  completed: Boolean
+  color: Color
 
-      "A field that requires an argument"
-      colors(
-        filter: [Color!]!
-      ): [Color!]!
-  }
+  "A field that requires an argument"
+  colors(filter: [Color!]!): [Color!]!
+}
 
-  type SimpleTodo {
+type SimpleTodo {
+  id: String!
+  name: String!
+}
+
+union TodoUnion = Todo | SimpleTodo
+
+input TodoInputType {
+  name: String!
+  completed: Boolean
+  color: Color = RED
+}
+
+enum Color {
+  "Red color"
+  RED
+  "Green color"
+  GREEN
+}
+
+type Query {
+  "A Query with 1 required argument and 1 optional argument"
+  todo(
     id: String!
-    name: String!
-  }
+    "A default value of false"
+    isCompleted: Boolean = false
+  ): Todo
 
-  union TodoUnion = Todo | SimpleTodo
+  "Returns a list (or null) that can contain null values"
+  todos(
+    "Reauired argument that is a list that cannot contain null values"
+    ids: [String!]!
+  ): [Todo]
+}
 
-  input TodoInputType {
-      name: String!
-      completed: Boolean
-      color: Color=RED
-  }
+type Mutation {
+  "A Mutation with 1 required argument"
+  create_todo(todo: TodoInputType!): Todo!
 
-  enum Color {
-      "Red color"
-      RED
-      "Green color"
-      GREEN
-  }
+  "A Mutation with 2 required arguments"
+  update_todo(id: String!, data: TodoInputType!): Todo!
 
-  type Query {
-      "A Query with 1 required argument and 1 optional argument"
-      todo(
-        id: String!,
-        "A default value of false"
-        isCompleted: Boolean=false
-      ): Todo
-
-      "Returns a list (or null) that can contain null values"
-      todos(
-        "Reauired argument that is a list that cannot contain null values"
-        ids: [String!]!
-      ): [Todo]
-  }
-
-  type Mutation {
-      "A Mutation with 1 required argument"
-      create_todo(
-        todo: TodoInputType!
-      ): Todo!
-
-      "A Mutation with 2 required arguments"
-      update_todo(
-        id: String!,
-        data: TodoInputType!
-      ): Todo!
-
-      "Returns a list (or null) that can contain null values"
-      update_todos(
-        ids: [String!]!
-        data: TodoInputType!
-      ): [Todo]
-  }
+  "Returns a list (or null) that can contain null values"
+  update_todos(ids: [String!]!, data: TodoInputType!): [Todo]
+}
 ```
 
 ### Output
@@ -308,7 +295,7 @@ const options = { nullableArrayItems: true }
       required: [ 'id', 'name' ]
     },
     TodoUnion: {
-      anyOf: [
+      oneOf: [
         { '$ref': '#/definitions/Todo' },
         { '$ref': '#/definitions/SimpleTodo' }
       ]

--- a/doc-exampleGenerator.ts
+++ b/doc-exampleGenerator.ts
@@ -25,6 +25,13 @@ const readmeSDL: string = `
       ): [Color!]!
   }
 
+  type SimpleTodo {
+    id: String!
+    name: String!
+  }
+
+  union TodoUnion = Todo | SimpleTodo
+
   input TodoInputType {
       name: String!
       completed: Boolean

--- a/doc-exampleGenerator.ts
+++ b/doc-exampleGenerator.ts
@@ -55,7 +55,7 @@ const readmeSDL: string = `
 
       "Returns a list (or null) that can contain null values"
       todos(
-        "Reauired argument that is a list that cannot contain null values"
+        "Required argument that is a list that cannot contain null values"
         ids: [String!]!
       ): [Todo]
   }

--- a/lib/reducer.ts
+++ b/lib/reducer.ts
@@ -13,6 +13,7 @@ import {
   isIntrospectionInputValue,
   isIntrospectionListTypeRef,
   isIntrospectionObjectType,
+  isIntrospectionUnionType,
   isNonNullIntrospectionType,
   isIntrospectionScalarType,
   isIntrospectionDefaultScalarType,
@@ -143,6 +144,10 @@ export const introspectionTypeReducer: (
         {}
       ),
       required: getRequiredFields(curr.inputFields),
+    }
+  } else if (isIntrospectionUnionType(curr)) {
+    acc[curr.name] = {
+      anyOf: curr.possibleTypes.map((type) => graphqlToJSONType(type, options)),
     }
   } else if (isIntrospectionEnumType(curr)) {
     acc[curr.name] = {

--- a/lib/reducer.ts
+++ b/lib/reducer.ts
@@ -147,7 +147,7 @@ export const introspectionTypeReducer: (
     }
   } else if (isIntrospectionUnionType(curr)) {
     acc[curr.name] = {
-      anyOf: curr.possibleTypes.map((type) => graphqlToJSONType(type, options)),
+      oneOf: curr.possibleTypes.map((type) => graphqlToJSONType(type, options)),
     }
   } else if (isIntrospectionEnumType(curr)) {
     acc[curr.name] = {

--- a/lib/typeGuards.ts
+++ b/lib/typeGuards.ts
@@ -12,6 +12,7 @@ import {
   IntrospectionSchema,
   IntrospectionType,
   IntrospectionTypeRef,
+  IntrospectionUnionType,
   IntrospectionScalarType,
 } from 'graphql'
 import { filter, has, startsWith, includes } from 'lodash'
@@ -48,6 +49,10 @@ export const isIntrospectionEnumType = (
   type: IntrospectionSchema['types'][0]
 ): type is IntrospectionEnumType => type.kind === 'ENUM'
 
+export const isIntrospectionUnionType = (
+  type: IntrospectionSchema['types'][0]
+): type is IntrospectionUnionType => type.kind === 'UNION'
+
 export const isNonNullIntrospectionType = (
   type: IntrospectionTypeRef
 ): type is IntrospectionNonNullTypeRef<
@@ -78,6 +83,7 @@ export const filterDefinitionsTypes = (
       ((isIntrospectionObjectType(type) && !!type.fields) ||
         (isIntrospectionInputObjectType(type) && !!type.inputFields) ||
         (isIntrospectionEnumType(type) && !!type.enumValues) ||
+        (isIntrospectionUnionType(type) && !!type.possibleTypes) ||
         (isIntrospectionScalarType(type) && !!type.name)) &&
       (!ignoreInternals || (ignoreInternals && !startsWith(type.name, '__')))
   )

--- a/test-utils.ts
+++ b/test-utils.ts
@@ -427,7 +427,7 @@ export const todoSchemaAsJsonSchema: JSONSchema6 = {
     },
     TodoUnion: {
       description: 'A Union of Todo and SimpleTodo',
-      anyOf: [
+      oneOf: [
         { $ref: '#/definitions/Todo' },
         { $ref: '#/definitions/SimpleTodo' },
       ],

--- a/test-utils.ts
+++ b/test-utils.ts
@@ -47,6 +47,15 @@ export const getTodoSchemaIntrospection = (): GetTodoSchemaIntrospectionResult =
             nullableFieldThatReturnsListOfNullableStrings: [String]
         }
 
+        "A simpler ToDo Object"
+        type SimpleTodo {
+          id: String!
+          name: String!
+        }
+
+        "A Union of Todo and SimpleTodo"
+        union TodoUnion = Todo | SimpleTodo
+
         """
         A type that describes ToDoInputType. Its description might not
         fit within the bounds of 80 width and so you want MULTILINE
@@ -366,6 +375,29 @@ export const todoSchemaAsJsonSchema: JSONSchema6 = {
       },
       required: ['id', 'name', 'requiredColors'],
     },
+    SimpleTodo: {
+      type: 'object',
+      description: 'A simpler ToDo Object',
+      properties: {
+        id: {
+          type: 'object',
+          properties: {
+            return: { $ref: '#/definitions/String' },
+            arguments: { type: 'object', properties: {}, required: [] },
+          },
+          required: [],
+        },
+        name: {
+          type: 'object',
+          properties: {
+            return: { $ref: '#/definitions/String' },
+            arguments: { type: 'object', properties: {}, required: [] },
+          },
+          required: [],
+        },
+      },
+      required: ['id', 'name'],
+    },
     Color: {
       // Yes, ENUM types should be the JSON built-in "string" type
       type: 'string',
@@ -392,6 +424,13 @@ export const todoSchemaAsJsonSchema: JSONSchema6 = {
         color: { default: 'RED', $ref: '#/definitions/Color' },
       },
       required: ['name'],
+    },
+    TodoUnion: {
+      description: 'A Union of Todo and SimpleTodo',
+      anyOf: [
+        { $ref: '#/definitions/Todo' },
+        { $ref: '#/definitions/SimpleTodo' },
+      ],
     },
   },
 }


### PR DESCRIPTION
Adds support for `UNION` types in GraphQL.

If you approve, please feel free to merge and then release for me, thanks!

Partially addresses what's done in https://github.com/charlypoly/graphql-to-json-schema/pull/8