### PR TITLE
Support complex default values

### DIFF
--- a/lib/reducer.ts
+++ b/lib/reducer.ts
@@ -1,3 +1,4 @@
+import JSON5 from 'json5'
 import {
   IntrospectionField,
   IntrospectionInputValue,
@@ -121,8 +122,8 @@ export const resolveDefaultValue = (curr: any) => {
     }
   }
   // Not an ENUM? No problem...just JSON parse it
-  if (!isIntrospectionEnumType(type)) {
-      return JSON.parse(curr.defaultValue)
+  if (typeof curr.defaultValue === 'string' && !isIntrospectionEnumType(type)) {
+      return JSON5.parse(curr.defaultValue)
   }
 
   if (!isList || !curr.defaultValue || typeof curr.defaultValue !== 'string') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
+        "json5": "^2.2.0",
         "lodash": "^4.17.20"
       },
       "devDependencies": {
@@ -6847,10 +6848,9 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
-      "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
-      "dev": true,
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
       "dependencies": {
         "minimist": "^1.2.5"
       },
@@ -7332,8 +7332,7 @@
     "node_modules/minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "node_modules/minimist-options": {
       "version": "4.1.0",
@@ -15984,10 +15983,9 @@
       "dev": true
     },
     "json5": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
-      "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
-      "dev": true,
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
       "requires": {
         "minimist": "^1.2.5"
       }
@@ -16364,8 +16362,7 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "minimist-options": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "node": ">=8"
   },
   "dependencies": {
+    "json5": "^2.2.0",
     "lodash": "^4.17.20"
   },
   "scripts": {

--- a/test-utils.ts
+++ b/test-utils.ts
@@ -68,15 +68,25 @@ export const getTodoSchemaIntrospection = (): GetTodoSchemaIntrospectionResult =
         fit within the bounds of 80 width and so you want MULTILINE
         """
         input TodoInputType {
-            name: String!
-            completed: Boolean
-            color: Color=RED
+          name: String!
+          completed: Boolean
+          color: Color=RED
+          contactInfo: ContactInfoInputType = {
+            email: "spam@example.dev"
+          }
+        }
+
+        """
+        Description of ContactInfoInputType.
+        """
+        input ContactInfoInputType {
+          email: String
         }
 
         "Anything with an ID can be a node"
         interface Node {
-            "A unique identifier"
-            id: String!
+          "A unique identifier"
+          id: String!
         }
 
         type Query {
@@ -511,8 +521,20 @@ export const todoSchemaAsJsonSchema: JSONSchema6 = {
         name: { $ref: '#/definitions/String' },
         completed: { $ref: '#/definitions/Boolean' },
         color: { default: 'RED', $ref: '#/definitions/Color' },
+        contactInfo: {
+          $ref: '#/definitions/ContactInfoInputType',
+          default: { email: 'spam@example.dev' }
+        },
       },
       required: ['name'],
+    },
+    ContactInfoInputType: {
+      type: 'object',
+      description: 'Description of ContactInfoInputType.',
+      properties: {
+        email: { $ref: "#/definitions/String" },
+      },
+      required: [],
     },
     TodoUnion: {
       description: 'A Union of Todo and SimpleTodo',


### PR DESCRIPTION
For complex default values, the string being passed to `JSON.parse` might look like `'{foo: "bar"}'`, which is a lax/incorrect JSON representation. Keys require `"double quotes"`.

The [`json5`](https://www.npmjs.com/package/json5) package seemed to be the best solution for handling this fact/situation. I don't love adding another dependency, but I don't think that (re-)implementing it here is a great idea. It also gets over 57mm downloads a week, so it seems solid.

Fixes https://github.com/charlypoly/graphql-to-json-schema/issues/67